### PR TITLE
Make sys.RestartApplication() work properly on Linux.

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -42,7 +42,7 @@ func (s *Supervisor) isServiceRunning() bool {
 		cmd = exec.Command("tasklist")
 	} else {
 		// Unix/Linux，假设'pgrep'可用
-		cmd = exec.Command("pgrep", "-f", s.Config.ProcessName)
+		cmd = exec.Command("pgrep", "-f", s.Config.ProcessName+".sh")
 	}
 
 	var out bytes.Buffer

--- a/sys/restart_unix.go
+++ b/sys/restart_unix.go
@@ -23,7 +23,7 @@ func NewRestarter() *UnixRestarter {
 func (r *UnixRestarter) Restart(executableName string) error {
 	scriptContent := "#!/bin/sh\n" +
 		"sleep 1\n" + // Sleep for a bit to allow the main application to exit
-		"." + executableName + "\n"
+		executableName + "\n"
 
 	scriptName := "restart.sh"
 	if err := os.WriteFile(scriptName, []byte(scriptContent), 0755); err != nil {

--- a/sys/restart_unix.go
+++ b/sys/restart_unix.go
@@ -59,7 +59,7 @@ func KillProcess() error {
 		cmd = exec.Command("taskkill", "/IM", "PalServer-Win64-Test-Cmd.exe", "/F")
 	} else {
 		// 非Windows: 使用pkill命令和进程名称
-		cmd = exec.Command("pkill", "-f", "PalServer-Win64-Test-Cmd.exe")
+		cmd = exec.Command("pkill", "-f", "PalServer-Linux-Test")
 	}
 
 	return cmd.Run()

--- a/sys/restart_windows.go
+++ b/sys/restart_windows.go
@@ -79,7 +79,7 @@ func KillProcess() error {
 		cmd = exec.Command("taskkill", "/IM", "PalServer-Win64-Test-Cmd.exe", "/F")
 	} else {
 		// 非Windows: 使用pkill命令和进程名称
-		cmd = exec.Command("pkill", "-f", "PalServer-Win64-Test-Cmd.exe")
+		cmd = exec.Command("pkill", "-f", "PalServer-Linux-Test")
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}


### PR DESCRIPTION
由于re.go:106中的GetExecutableName返回的是绝对路径，此处不需要加定位符
修复sys/restart_unix.go和sys/restart_windows.go中的文件名称错误