### PR TITLE
update publiclobby and rcon config.

### DIFF
--- a/front/palworld-front/src/pages/IndexView.vue
+++ b/front/palworld-front/src/pages/IndexView.vue
@@ -71,7 +71,7 @@
           />
           <q-toggle
             v-model="config.communityServer"
-            label="启动为社区服务器(需设置steam路径)"
+            label="启动为社区服务器"
             class="q-my-md"
           />
           <q-toggle
@@ -144,12 +144,6 @@
             filled
             v-model="config.backupPath"
             label="游戏存档备份存放路径"
-            class="q-my-md"
-          />
-          <q-input
-            filled
-            v-model="config.steamPath"
-            label="Steam安装路径(启动社区服务器用)"
             class="q-my-md"
           />
           <q-input

--- a/sys/restart_unix.go
+++ b/sys/restart_unix.go
@@ -90,6 +90,15 @@ func RestartService(config config.Config) {
 		fmt.Sprintf("-players=%d", config.WorldSettings.ServerPlayerMaxNum),
 	}
 
+	if config.CommunityServer {
+		args = append(args, "-publiclobby")
+	}
+
+	// 如果RCON启用，则添加RCON参数
+	if config.WorldSettings.RconEnabled {
+		args = append(args, "-rcon")
+	}
+
 	args = append(args, config.ServerOptions...) // 添加GameWorldSettings参数
 
 	// 执行启动命令

--- a/sys/restart_windows.go
+++ b/sys/restart_windows.go
@@ -210,10 +210,7 @@ func RestartService(config config.Config) {
 
 	//发送机器人推送
 	bot.SendCommandMessages("run", config)
-	if config.CommunityServer {
-		exePath = filepath.Join(config.SteamPath, "Steam.exe")
-		args = []string{"-applaunch", "2394010"}
-	} else if config.UseDll {
+	if config.UseDll {
 		err := mod.CheckAndWriteFiles(filepath.Join(config.GamePath, "Pal", "Binaries", "Win64"))
 		if err != nil {
 			log.Printf("Failed to write files: %v", err)
@@ -242,6 +239,17 @@ func RestartService(config config.Config) {
 			fmt.Sprintf("-port=%d", config.WorldSettings.PublicPort),
 			fmt.Sprintf("-players=%d", config.WorldSettings.ServerPlayerMaxNum),
 		}
+	}
+
+	if config.CommunityServer {
+		// https://tech.palworldgame.com/getting-started/deploy-community-server
+		// 启动社区服务器可以直接使用PalSerer.exe 启动
+		args = append(args, "-publiclobby")
+	}
+
+	// 如果RCON启用，则添加RCON参数
+	if config.WorldSettings.RconEnabled {
+		args = append(args, "-rcon")
 	}
 
 	args = append(args, config.ServerOptions...) // 添加GameWorldSettings参数

--- a/tool/rcon.go
+++ b/tool/rcon.go
@@ -145,7 +145,7 @@ func Broadcast(config config.Config, message string) error {
 		}
 		defer exec.Close()
 
-		response, err := exec.Execute("Broadcast " + strings.ReplaceAll(message, " ", "_"))
+		response, err := exec.Execute("broadcast " + strings.ReplaceAll(message, " ", "_"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
社区服务问题（指可以在社区列表中被检索）
来源：https://tech.palworldgame.com/getting-started/deploy-community-server

Add the following options to the startup arguments.

Example
PalServer.exe -publiclobby
rcon无法使用,自己在本地测试需要加上 -rcon

同时使用默认的broadcast无法使用，进行修正后测试可用.